### PR TITLE
Note deletion endpoint

### DIFF
--- a/src/main/java/pl/edu/uj/notes/advice/GlobalExceptionHandler.java
+++ b/src/main/java/pl/edu/uj/notes/advice/GlobalExceptionHandler.java
@@ -4,6 +4,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import pl.edu.uj.notes.note.exceptions.NoteNotFoundException;
 import pl.edu.uj.notes.user.exceptions.UserNotFoundException;
 
 @RestControllerAdvice
@@ -16,6 +17,11 @@ public class GlobalExceptionHandler {
 
   @ExceptionHandler(UserNotFoundException.class)
   public ResponseEntity<String> handleUserNotFoundException(UserNotFoundException e) {
+    return ResponseEntity.status(HttpStatus.NOT_FOUND).body(e.getMessage());
+  }
+
+  @ExceptionHandler(NoteNotFoundException.class)
+  public ResponseEntity<String> handleNoteNotFoundException(NoteNotFoundException e) {
     return ResponseEntity.status(HttpStatus.NOT_FOUND).body(e.getMessage());
   }
 }

--- a/src/main/java/pl/edu/uj/notes/note/DeleteNoteRequest.java
+++ b/src/main/java/pl/edu/uj/notes/note/DeleteNoteRequest.java
@@ -1,0 +1,5 @@
+package pl.edu.uj.notes.note;
+
+import jakarta.validation.constraints.NotBlank;
+
+record DeleteNoteRequest(@NotBlank String id) {}

--- a/src/main/java/pl/edu/uj/notes/note/Note.java
+++ b/src/main/java/pl/edu/uj/notes/note/Note.java
@@ -22,6 +22,8 @@ public class Note {
 
   @LastModifiedDate private Instant updatedAt;
 
+  private boolean active = true;
+
   public Note(String title) {
     this.title = title;
   }

--- a/src/main/java/pl/edu/uj/notes/note/NoteController.java
+++ b/src/main/java/pl/edu/uj/notes/note/NoteController.java
@@ -5,11 +5,7 @@ import java.net.URI;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.ResponseStatus;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -23,5 +19,12 @@ class NoteController {
   ResponseEntity<Void> createNote(@Valid @RequestBody CreateNoteRequest request) throws Exception {
     var location = new URI("api/v1/notes/" + noteService.createNote(request));
     return ResponseEntity.created(location).build();
+  }
+
+  @DeleteMapping
+  @ResponseStatus(HttpStatus.NO_CONTENT)
+  ResponseEntity<Void> deleteNote(@Valid @RequestBody DeleteNoteRequest request) {
+    noteService.deleteNote(request);
+    return ResponseEntity.noContent().build();
   }
 }

--- a/src/main/java/pl/edu/uj/notes/note/NoteService.java
+++ b/src/main/java/pl/edu/uj/notes/note/NoteService.java
@@ -1,8 +1,10 @@
 package pl.edu.uj.notes.note;
 
 import jakarta.transaction.Transactional;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
+import pl.edu.uj.notes.note.exceptions.NoteNotFoundException;
 
 @Component
 @RequiredArgsConstructor
@@ -19,5 +21,19 @@ public class NoteService {
     NoteSnapshot noteSnapshot = new NoteSnapshot(note, request.content());
     noteSnapshotRepository.save(noteSnapshot).getId();
     return note.getId();
+  }
+
+  void deleteNote(DeleteNoteRequest request) {
+    String id = request.id();
+
+    Optional<Note> noteOptional = noteRepository.findById(id);
+
+    if (noteOptional.isPresent()) {
+      Note note = noteOptional.get();
+      note.setActive(false);
+      noteRepository.save(note);
+    } else {
+      throw new NoteNotFoundException("Note with ID " + id + " does not exist");
+    }
   }
 }

--- a/src/main/java/pl/edu/uj/notes/note/exceptions/NoteNotFoundException.java
+++ b/src/main/java/pl/edu/uj/notes/note/exceptions/NoteNotFoundException.java
@@ -1,0 +1,7 @@
+package pl.edu.uj.notes.note.exceptions;
+
+public class NoteNotFoundException extends RuntimeException {
+  public NoteNotFoundException(String message) {
+    super(message);
+  }
+}

--- a/src/main/resources/db/changelog.xml
+++ b/src/main/resources/db/changelog.xml
@@ -48,4 +48,10 @@
     </addColumn>
   </changeSet>
 
+  <changeSet id="5" author="wzdeb">
+    <addColumn tableName="note">
+      <column name="active" type="boolean" defaultValueBoolean="true"/>
+    </addColumn>
+  </changeSet>
+
 </databaseChangeLog>

--- a/src/test/java/pl/edu/uj/notes/note/NoteControllerTest.java
+++ b/src/test/java/pl/edu/uj/notes/note/NoteControllerTest.java
@@ -81,7 +81,7 @@ class NoteControllerTest {
     var request =
         """
             {
-              "id": null,
+              "id": null
             }
             """;
 
@@ -98,13 +98,13 @@ class NoteControllerTest {
     var request =
         """
             {
-              "id": "non-existing-id",
+              "id": "non-existing-id"
             }
             """;
 
     Mockito.doThrow(new NoteNotFoundException("Note with ID " + id + " does not exist"))
         .when(noteService)
-        .deleteNote(new DeleteNoteRequest(id));
+        .deleteNote(deleteNoteRequest);
 
     mockMvc
         .perform(delete(NOTE_URI).contentType(MediaType.APPLICATION_JSON).content(request))
@@ -119,7 +119,7 @@ class NoteControllerTest {
     var request =
         """
             {
-              "id": "existing-id",
+              "id": "existing-id"
             }
             """;
 

--- a/src/test/java/pl/edu/uj/notes/note/NoteControllerTest.java
+++ b/src/test/java/pl/edu/uj/notes/note/NoteControllerTest.java
@@ -1,9 +1,11 @@
 package pl.edu.uj.notes.note;
 
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
@@ -12,6 +14,7 @@ import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import pl.edu.uj.notes.authentication.SecurityConfig;
+import pl.edu.uj.notes.note.exceptions.NoteNotFoundException;
 import pl.edu.uj.notes.user.UserService;
 
 @WebMvcTest(NoteController.class)
@@ -70,5 +73,60 @@ class NoteControllerTest {
     mockMvc
         .perform(post(NOTE_URI).contentType(MediaType.APPLICATION_JSON).content(request))
         .andExpect(status().isCreated());
+  }
+
+  @Test
+  @WithMockUser
+  void deleteNote_blankId_badRequest() throws Exception {
+    var request =
+        """
+            {
+              "id": null,
+            }
+            """;
+
+    mockMvc
+        .perform(delete(NOTE_URI).contentType(MediaType.APPLICATION_JSON).content(request))
+        .andExpect(status().isBadRequest());
+  }
+
+  @Test
+  @WithMockUser
+  void deleteNote_noteNotFound_returnsNotFound() throws Exception {
+    String id = "non-existing-id";
+    DeleteNoteRequest deleteNoteRequest = new DeleteNoteRequest(id);
+    var request =
+        """
+            {
+              "id": "non-existing-id",
+            }
+            """;
+
+    Mockito.doThrow(new NoteNotFoundException("Note with ID " + id + " does not exist"))
+        .when(noteService)
+        .deleteNote(new DeleteNoteRequest(id));
+
+    mockMvc
+        .perform(delete(NOTE_URI).contentType(MediaType.APPLICATION_JSON).content(request))
+        .andExpect(status().isNotFound());
+  }
+
+  @Test
+  @WithMockUser
+  void deleteNote_noteExists_noContent() throws Exception {
+    String id = "existing-id";
+
+    var request =
+        """
+            {
+              "id": "existing-id",
+            }
+            """;
+
+    Mockito.doNothing().when(noteService).deleteNote(new DeleteNoteRequest(id));
+
+    mockMvc
+        .perform(delete(NOTE_URI).contentType(MediaType.APPLICATION_JSON).content(request))
+        .andExpect(status().isNoContent());
   }
 }


### PR DESCRIPTION
Invoking deleteNote endpoint sets "Active" field of specified note to 'false' (by default it's set to 'true'').
If note with given id does not exist, NoteNotFoundException is thrown.

Please take a closer look at tests - I'm not 100% sure if I set them up right